### PR TITLE
Feature: Add support for dumping schema to a file and loading from it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ strategy is SimpleStrategy with a Replication Factor of 3.
 * ```cassandra.migrate``` - Runs all missing migrations against the keyspace.
 * ```cassandra.add_migration --name migration_name``` - Generates a migration file under ```db/migrations``` with the 
 current timestamp prepended to the provided ```--name``` value.
+* ```cassandra.dump_schema``` - Dumps the current schmea to ```db/schema.cql```. Be careful when using this feature when
+ Solr is enabled.
+* ```cassandra.load_schema``` - Loads the schema from ```db/schema.cql```. This may be faster than running all 
+migrations in a project. 
 
 Example: ```inv cassandra.create cassandra.migrate``` - Creates the keyspaces and runs all migrations
 

--- a/db/migrators/cassandra.py
+++ b/db/migrators/cassandra.py
@@ -99,14 +99,20 @@ def migrate():
         else:
             print('All migrations have already been run.')
 
-        # Dump the current schema to disk
-        schema = check_output("cqlsh -k {} -e \"DESCRIBE KEYSPACE\" {}".format(keyspace, contact_point), shell=True,
-                              universal_newlines=True)
-        schema_file = open('db/schema.cql', 'w')
-        schema_file.write(schema)
-        schema_file.close()
+        dump_schema()
 
     disconnect()
+
+
+@task
+def dump_schema():
+    contact_point = contact_points[0]
+    schema = check_output("cqlsh -k {} -e \"DESCRIBE KEYSPACE\" {}".format(keyspace, contact_point), shell=True,
+                          universal_newlines=True)
+    schema_file = open('db/schema.cql', 'w')
+    schema_file.write(schema)
+    schema_file.close()
+
 
 @task
 def load_schema():

--- a/db/migrators/cassandra.py
+++ b/db/migrators/cassandra.py
@@ -1,6 +1,6 @@
 from invoke import task
 import os
-from subprocess import call
+from subprocess import call, check_output
 from cassandra.cluster import Cluster
 import datetime
 from db.config import contact_points, keyspace, migration_master
@@ -96,6 +96,13 @@ def migrate():
                         session.execute(insert_statement, [migration])
         else:
             print('All migrations have already been run.')
+
+        # Dump the current schema to disk
+        schema = check_output("cqlsh -k {} -e \"DESCRIBE KEYSPACE\" {}".format(keyspace, contact_point), shell=True,
+                              universal_newlines=True)
+        schema_file = open('db/schema.cql', 'w')
+        schema_file.write(schema)
+        schema_file.close()
 
     disconnect()
 


### PR DESCRIPTION
Fixes: #2 

## New Tasks
* ```cassandra.dump_schema``` - Dumps the schema to ```db/schema.cql```
* ```cassandra.load_schema``` - Loads a schema from ```db/schema.cql```. 

## Known Issues
```cassandra.load_schema``` will have issues if the keyspace already exists. Running ```load_schema``` on top of an existing schema will most likely leave the keyspace in a broken state.
