### PR TITLE
Support new Invoke version, direct C* calls and data migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Trireme
+
 Trireme is a tool providing migration support for Apache Cassandra, DataStax Enterprise Cassandra & Solr. Commands are run using the Python [Invoke](https://github.com/pyinvoke/invoke) CLI tool.
 
 ## System Dependencies

--- a/trireme/migrators/cassandra.py
+++ b/trireme/migrators/cassandra.py
@@ -1,19 +1,23 @@
 from __future__ import absolute_import
 from invoke import task, run
 import os
+from cassandra import ConsistencyLevel
 from cassandra.cluster import Cluster
 from cassandra.auth import PlainTextAuthProvider
+from cassandra.query import BatchStatement, SimpleStatement
 import datetime
-from config import contact_points, keyspace, migration_master, username, password, replication
+from trireme_config import contact_points, keyspace, migration_master, username, password, replication
 import json
 
 contact_point = contact_points[0]
 cluster = None
 session = None
 
+
 def connect(migration_keyspace):
     global cluster, session
 
+    print("contact points: {}".format(contact_points))
     # Setup the auth provider
     auth_provider = PlainTextAuthProvider(username=username, password=password)
 
@@ -50,93 +54,116 @@ def cqlsh_command(**kwargs):
     return command
 
 
+def master():
+    """
+    Fail if this is not the migration master.
+    """
+    if not migration_master:
+        raise Exception("Not the migration master (set migration_master=True)")
+
+
 @task
 def create():
-    if migration_master:
-        # Note we use the system keyspace in connect call since the target keyspace doesn't exist yet.
-        connect('system')
+    master()
+    # Note we use the system keyspace in connect call since the target keyspace doesn't exist yet.
+    connect('system')
 
-        # Create the keyspace
-        replication_string = json.dumps(replication).replace('"', "'")
-        print("Creating keyspace {} with replication options: {}".format(keyspace, replication_string))
-        session.execute("CREATE KEYSPACE IF NOT EXISTS {} "
-                        "WITH REPLICATION = {}".format(keyspace, replication_string))
+    # Create the keyspace
+    replication_string = json.dumps(replication).replace('"', "'")
+    print("Creating keyspace {} with replication options: {}".format(keyspace, replication_string))
+    session.execute("CREATE KEYSPACE IF NOT EXISTS {} "
+                    "WITH REPLICATION = {}".format(keyspace, replication_string))
 
-        # Add the migrations table transparently, this will track which migrations have been run
-        session.execute("CREATE TABLE IF NOT EXISTS {}.migrations ("
-                        "migration text, "
-                        "PRIMARY KEY(migration));".format(keyspace))
-        
-        print('Keyspace {} created'.format(keyspace))
+    # Add the migrations table transparently, this will track which migrations have been run
+    session.execute("CREATE TABLE IF NOT EXISTS {}.migrations ("
+                    "migration text, "
+                    "PRIMARY KEY(migration));".format(keyspace))
 
-        disconnect()
+    print('Keyspace {} created'.format(keyspace))
+
+    disconnect()
 
 
 @task
 def drop():
-    if migration_master:
-        # Connect to Cassandra
-        connect(keyspace)
+    master()
+    # Connect to Cassandra
+    connect(keyspace)
 
-        # Drop the keyspace
-        print("Dropping keyspace {}".format(keyspace))
-        session.execute("DROP KEYSPACE {}".format(keyspace))
+    # Drop the keyspace
+    print("Dropping keyspace {}".format(keyspace))
+    session.execute("DROP KEYSPACE {}".format(keyspace))
 
-        disconnect()
+    disconnect()
 
 
 @task
 def migrate():
-    if migration_master:
-        # Connect to Cassandra
-        connect(keyspace)
+    master()
+    # Connect to Cassandra
+    connect(keyspace)
 
-        # Pull all migrations from the disk
-        print('Loading migrations')
+    # Pull all migrations from the disk
+    print('Loading migrations')
 
-        # Load migrations from disk
-        disk_migrations = os.listdir('db/migrations')
-        for disk_migration in disk_migrations:
-            if not disk_migration.endswith('.cql'):
-                disk_migrations.remove(disk_migration)
+    # Load migrations from disk
+    disk_migrations = os.listdir('db/migrations')
+    for disk_migration in disk_migrations:
+        if not disk_migration.endswith('.cql'):
+            disk_migrations.remove(disk_migration)
 
-        # Pull all migrations from C*
-        results = session.execute("SELECT * FROM {}.migrations".format(keyspace))
-        for row in results:  # Remove any disk migration that matches this record
-            disk_migrations.remove(row.migration)
+    # Pull all migrations from C*
+    results = session.execute("SELECT * FROM {}.migrations".format(keyspace))
+    for row in results:  # Remove any disk migration that matches this record
+        disk_migrations.remove(row.migration)
 
-        if len(disk_migrations) > 0:  # Sort the disk migrations, to ensure they are run in order
-            disk_migrations.sort()  # Prepare the migrations table insert statement
+    if len(disk_migrations) > 0:  # Sort the disk migrations, to ensure they are run in order
+        disk_migrations.sort()  # Prepare the migrations table insert statement
 
-            insert_statement = session.prepare("INSERT INTO {}.migrations (migration) VALUES (?)".format(keyspace))
+        insert_statement = session.prepare("INSERT INTO {}.migrations (migration) VALUES (?)".format(keyspace))
 
-            # Iterate over remaining migrations and run them
-            for migration in disk_migrations:
-                if migration.endswith('.cql'):
-                    print("Running migration: {}".format(migration))
+        # Iterate over remaining migrations and run them
+        for migration in disk_migrations:
+            if migration.endswith('.cql'):
+                print("Running migration: {}".format(migration))
 
-                    result = run(cqlsh_command(f="db/migrations/{}".format(migration), k=keyspace), hide='stdout')
+                # result = run(cqlsh_command(f="db/migrations/{}".format(migration), k=keyspace), hide='stdout')
+                with open("db/migrations/{}".format(migration), 'r') as f:
+                    #TODO: Fix with real cql statement parsing.  It is
+                    #included in the cqlsh python lib but not easily
+                    #extracted.
+                    queries = f.read().split(';')
 
-                    if result.ok:
-                        session.execute(insert_statement, [migration])
-        else:
-            print('All migrations have already been run.')
+                    batch = BatchStatement(consistency_level=ConsistencyLevel.QUORUM)
+                    for query in queries:
+                        query = query.strip()
+                        if query:
+                            try:
+                                session.execute(SimpleStatement(query))
+                            except Exception:
+                                print('Query failed, migration partially applied: "{}"'.format(query))
+                                raise
+                    session.execute(batch)
+                session.execute(insert_statement, [migration])
+    else:
+        print('All migrations have already been run.')
 
-        dump_schema()
+    dump_schema()
 
     disconnect()
 
 
 @task
 def dump_schema():
-    result = run(cqlsh_command(k=keyspace, e="DESCRIBE KEYSPACE {}".format(keyspace)), hide='stdout')
-    schema_file = open('db/schema.cql', 'w')
-    schema_file.write(result.stdout)
-    schema_file.close()
+    master()
+    with open('db/schema.cql', 'w') as schema_file:
+        keyspace_info = cluster.metadata.keyspaces.get(keyspace)
+        schema_file.write(keyspace_info.export_as_string())
 
 
 @task
 def load_schema():
+    master()
     print('Verifying keyspace is not present')
     connect('system')
     rows = session.execute('SELECT * FROM schema_keyspaces WHERE keyspace_name = %s', [keyspace])
@@ -171,6 +198,7 @@ def load_schema():
 
 @task(help={'name': 'Name of the migration. Ex: add_users_table'})
 def add_migration(name):
+    master()
     if name:
         timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M')
         path = "db/migrations/{}_{}.cql".format(timestamp, name)

--- a/trireme/migrators/cassandra.py
+++ b/trireme/migrators/cassandra.py
@@ -148,7 +148,7 @@ def migrate(ctx):
     else:
         print('All migrations have already been run.')
 
-    dump_schema()
+    dump_schema(ctx)
 
     disconnect()
 

--- a/trireme/migrators/cassandra.py
+++ b/trireme/migrators/cassandra.py
@@ -63,7 +63,7 @@ def master():
 
 
 @task
-def create():
+def create(ctx):
     master()
     # Note we use the system keyspace in connect call since the target keyspace doesn't exist yet.
     connect('system')
@@ -85,7 +85,7 @@ def create():
 
 
 @task
-def drop():
+def drop(ctx):
     master()
     # Connect to Cassandra
     connect(keyspace)
@@ -98,7 +98,7 @@ def drop():
 
 
 @task
-def migrate():
+def migrate(ctx):
     master()
     # Connect to Cassandra
     connect(keyspace)
@@ -154,7 +154,7 @@ def migrate():
 
 
 @task
-def dump_schema():
+def dump_schema(ctx):
     master()
     with open('db/schema.cql', 'w') as schema_file:
         keyspace_info = cluster.metadata.keyspaces.get(keyspace)
@@ -162,7 +162,7 @@ def dump_schema():
 
 
 @task
-def load_schema():
+def load_schema(ctx):
     master()
     print('Verifying keyspace is not present')
     connect('system')
@@ -197,7 +197,7 @@ def load_schema():
 
 
 @task(help={'name': 'Name of the migration. Ex: add_users_table'})
-def add_migration(name):
+def add_migration(ctx, name):
     master()
     if name:
         timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M')

--- a/trireme/migrators/data.py
+++ b/trireme/migrators/data.py
@@ -1,0 +1,107 @@
+"""
+The data migrator enables migrations that modify records in a cassandra
+database.
+
+If the migration completes successfully, the migration is recorded in the
+migrations table so it is never run again.
+"""
+
+from __future__ import absolute_import
+from invoke import task, run
+import os
+from cassandra.cluster import Cluster
+from cassandra.auth import PlainTextAuthProvider
+import datetime
+import subprocess
+from trireme_config import contact_points, keyspace, migration_master, username, password, replication
+
+contact_point = contact_points[0]
+cluster = None
+session = None
+
+
+def connect(migration_keyspace):
+    global cluster, session
+
+    # Setup the auth provider
+    auth_provider = PlainTextAuthProvider(username=username, password=password)
+
+    # Contact to Cassandra
+    cluster = Cluster(contact_points, auth_provider=auth_provider)
+    session = cluster.connect(migration_keyspace)
+
+
+def disconnect():
+    session.shutdown()
+    cluster.shutdown()
+
+
+def authentication_enabled():
+    return username and password
+
+
+def master():
+    """
+    Fail if this is not the migration master.
+    """
+    if not migration_master:
+        raise Exception("Not the migration master (set migration_master=True)")
+
+
+@task
+def migrate():
+    master()
+    # Connect to Cassandra
+    connect(keyspace)
+
+    # Pull all migrations from the disk
+    print('Loading migrations')
+
+    # Load migrations from disk
+    disk_migrations = os.listdir('db/data')
+    for disk_migration in disk_migrations:
+        if not disk_migration.endswith('.py'):
+            disk_migrations.remove(disk_migration)
+
+    # Pull all migrations from C*
+    results = session.execute("SELECT * FROM {}.migrations".format(keyspace))
+    for row in results:  # Remove any disk migration that matches this record
+        if row.migration in disk_migrations:
+            disk_migrations.remove(row.migration)
+
+    if len(disk_migrations) > 0:  # Sort the disk migrations, to ensure they are run in order
+        disk_migrations.sort()  # Prepare the migrations table insert statement
+
+        insert_statement = session.prepare("INSERT INTO {}.migrations (migration) VALUES (?)".format(keyspace))
+
+        # Iterate over remaining migrations and run them
+        for migration in disk_migrations:
+            if migration.endswith('.py'):
+                print("Running migration: {}".format(migration))
+
+                cmd = ["/app/.heroku/python/bin/python", migration]
+                result = subprocess.run(cmd, cwd='/app/db/trireme/db/data', env={'PYTHONPATH': '/app', 'ENVIRONMENT': os.getenv('ENVIRONMENT')}, stdout=subprocess.PIPE)
+                if result.returncode != 0:
+                    print("Script returned {}. Migration partially applied.".format(result.returncode))
+                    print("Script output:")
+                    print(result.stdout.decode('utf-8'))
+                else:
+                    session.execute(insert_statement, [migration])
+    else:
+        print('All migrations have already been run.')
+
+    disconnect()
+
+
+@task(help={'name': 'Name of the migration. Ex: update_users_session'})
+def add_migration(name):
+    master()
+    if name:
+        timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M')
+        path = "db/data/{}_{}.py".format(timestamp, name)
+        fd = open(path, 'w')
+        fd.close()
+
+        print("Created migration: {}".format(path))
+    else:
+        print('Call add_migration with the --name parameter specifying a name for the migration. Ex: update_users_session')

--- a/trireme/migrators/data.py
+++ b/trireme/migrators/data.py
@@ -49,7 +49,7 @@ def master():
 
 
 @task
-def migrate():
+def migrate(ctx):
     master()
     # Connect to Cassandra
     connect(keyspace)
@@ -94,7 +94,7 @@ def migrate():
 
 
 @task(help={'name': 'Name of the migration. Ex: update_users_session'})
-def add_migration(name):
+def add_migration(ctx, name):
     master()
     if name:
         timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M')

--- a/trireme/migrators/solr.py
+++ b/trireme/migrators/solr.py
@@ -3,7 +3,7 @@ from invoke import task
 from requests.auth import HTTPBasicAuth
 import requests
 import os
-from config import solr_url, username, password
+from trireme_config import solr_url, username, password
 
 auth = HTTPBasicAuth(username, password)
 
@@ -27,8 +27,17 @@ def find_cores():
     return cores
 
 
+def master():
+    """
+    Fail if this is not the migration master.
+    """
+    if not migration_master:
+        raise Exception("Not the migration master (set migration_master=True)")
+
+
 @task(help={'core': 'Name of the core to run against. Omitting this value will create all cores'})
 def create(core=None):
+    master()
     cores = []
     if core:
         cores.append(core)
@@ -55,6 +64,7 @@ def create(core=None):
 
 @task(help={'core': 'Name of the core to run against. Omitting this value will create all cores'})
 def migrate(core=None):
+    master()
     cores = []
     if core:
         cores.append(core)
@@ -82,6 +92,7 @@ def migrate(core=None):
 
 @task(help={'name': 'Name of the core you want to create'})
 def add_core(name):
+    master()
     if name:
         path = "db/solr/{}".format(name)
         if os.path.exists(path):

--- a/trireme/migrators/solr.py
+++ b/trireme/migrators/solr.py
@@ -36,7 +36,7 @@ def master():
 
 
 @task(help={'core': 'Name of the core to run against. Omitting this value will create all cores'})
-def create(core=None):
+def create(ctx, core=None):
     master()
     cores = []
     if core:
@@ -63,7 +63,7 @@ def create(core=None):
 
 
 @task(help={'core': 'Name of the core to run against. Omitting this value will create all cores'})
-def migrate(core=None):
+def migrate(ctx, core=None):
     master()
     cores = []
     if core:
@@ -91,7 +91,7 @@ def migrate(core=None):
 
 
 @task(help={'name': 'Name of the core you want to create'})
-def add_core(name):
+def add_core(ctx, name):
     master()
     if name:
         path = "db/solr/{}".format(name)

--- a/trireme/trireme.py
+++ b/trireme/trireme.py
@@ -1,15 +1,15 @@
 from __future__ import absolute_import
 import os
 from invoke import Collection, task
-from trireme.migrators import cassandra, solr
+from trireme.migrators import cassandra, solr, data
 
 
 @task
 def setup():
     # Create the necessary directories
-    directories = ['db', 'db/solr', 'db/migrations']
+    directories = ['db', 'db/solr', 'db/migrations', 'db/data']
     for directory in directories:
         os.makedirs(directory)
 
-ns = Collection(cassandra, solr)
+ns = Collection(cassandra, solr, data)
 ns.add_task(setup)

--- a/trireme/trireme.py
+++ b/trireme/trireme.py
@@ -5,7 +5,7 @@ from trireme.migrators import cassandra, solr, data
 
 
 @task
-def setup():
+def setup(ctx):
     # Create the necessary directories
     directories = ['db', 'db/solr', 'db/migrations', 'db/data']
     for directory in directories:


### PR DESCRIPTION
- Works with Invoke==0.13.0
- Makes direct Cassandra connections where possible, rather than relying on cqlsh.  My use case involves using the config file from my app rather than a separate config file for Trireme, and this changes makes it possible to integrate Trireme this way.
- Adds support for data migrations

This works for my use case, but cqlsh has some behavior that my changes don't strictly reproduce.  If you think it would be needed, I could have the use of cqlsh be configurable via a flag of some sort.  Let me know what you think.