### PR TITLE
Gracefully handle migrations deleted from disk

### DIFF
--- a/trireme/migrators/cassandra.py
+++ b/trireme/migrators/cassandra.py
@@ -115,7 +115,8 @@ def migrate(ctx):
     # Pull all migrations from C*
     results = session.execute("SELECT * FROM {}.migrations".format(keyspace))
     for row in results:  # Remove any disk migration that matches this record
-        disk_migrations.remove(row.migration)
+        if row.migration in disk_migrations:
+            disk_migrations.remove(row.migration)
 
     if len(disk_migrations) > 0:  # Sort the disk migrations, to ensure they are run in order
         disk_migrations.sort()  # Prepare the migrations table insert statement


### PR DESCRIPTION
I inadvertently added a crasher that occurs when there is a migration entry in the database but the file no longer exists on disk.  This change fixes it.

This situation happens when someone deletes a migration file that has been run, and when switching between code branches.