### PR TITLE
Using relative paths for the cmd and cwd. 

### DIFF
--- a/trireme/migrators/cassandra.py
+++ b/trireme/migrators/cassandra.py
@@ -115,7 +115,8 @@ def migrate(ctx):
     # Pull all migrations from C*
     results = session.execute("SELECT * FROM {}.migrations".format(keyspace))
     for row in results:  # Remove any disk migration that matches this record
-        disk_migrations.remove(row.migration)
+        if row.migration in disk_migrations:
+            disk_migrations.remove(row.migration)
 
     if len(disk_migrations) > 0:  # Sort the disk migrations, to ensure they are run in order
         disk_migrations.sort()  # Prepare the migrations table insert statement

--- a/trireme/migrators/data.py
+++ b/trireme/migrators/data.py
@@ -79,8 +79,8 @@ def migrate(ctx):
             if migration.endswith('.py'):
                 print("Running migration: {}".format(migration))
 
-                cmd = ["/app/.heroku/python/bin/python", migration]
-                result = subprocess.run(cmd, cwd='/app/db/trireme/db/data', env={'PYTHONPATH': '/app', 'ENVIRONMENT': os.getenv('ENVIRONMENT')}, stdout=subprocess.PIPE)
+                cmd = ["python", migration]
+                result = subprocess.run(cmd, cwd='db/data', env={'PYTHONPATH': os.getenv('PYTHONPATH'), 'ENVIRONMENT': os.getenv('ENVIRONMENT')}, stdout=subprocess.PIPE)
                 if result.returncode != 0:
                     print("Script returned {}. Migration partially applied.".format(result.returncode))
                     print("Script output:")


### PR DESCRIPTION
Also allows callers to specify their own PYTHONPATH.

Callers can CD into the trireme directory and set their environment and python path. 

For example:
`cd db/trireme `
`export ENVIRONMENT=development`
`export PYTHONPATH=/srv/homedir`
`invoke trireme.data.migrate`


This PR aims to fix the hard coded paths, like:
`FileNotFoundError: [Errno 2] No such file or directory: '/app/.heroku/python/bin/python'`
